### PR TITLE
Allow cross-domain requests for CSS files

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ css-inliner <url> [options]
 * `-t, --insertion-token [string]` - A token (preferably an HTML comment) to control the exact insertion point of the inlined CSS. If omited default insertion is at the first encountered stylesheet.
 * `-i, --css-id [string]` - Determines the id attribute of the inline style tag. By default no id is added.
 * `-f,  --fake-url` - Defines a _fake_ url context. Required when piping in html through `stdin`. Default is null.
+* `-x,  --allow-cross-domain` - Allow cross-domain requests (e.g. CSS is located on CDN domain).
 * `-d, --debug` - Prints out an HTML comment in the bottom of the output that exposes some info:
   * `time` - The time in ms it took to run the script (not including the phantomjs process itself).
   * `loadTime` - The time in ms it took to load the webpage.

--- a/extractCSS.js
+++ b/extractCSS.js
@@ -3,7 +3,7 @@
 	var html = doc.documentElement;
 	var width, height;
 	var options = global.extractCSSOptions;
-	var matchMQ, required;
+	var matchMQ, allowCrossDomain, required;
 	var stylesheets = [];
 	var mediaStylesheets = [];
 	var left;
@@ -12,6 +12,9 @@
 	if (options) {
 		if ("matchMQ" in options) {
 			matchMQ = options.matchMQ;
+		}
+		if ("allowCrossDomain" in options) {
+			allowCrossDomain = options.allowCrossDomain;
 		}
 		if ("required" in options) {
 			required = options.required;
@@ -38,8 +41,7 @@
 		var host = global.location.protocol + "//" + global.location.host;
 
 		mediaStylesheets.forEach(function (stylesheet) {
-			// avoid crossdomain requests
-			if (stylesheet.href && stylesheet.href.indexOf(host) === 0) {
+			if ((stylesheet.href && stylesheet.href.indexOf(host) === 0) || (stylesheet.href && allowCrossDomain)) {
 				fetchStylesheet(stylesheet.href, function (text) {
 					var index = left.indexOf(stylesheet);
 					if (index > -1) {

--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ var value;
 var width = 1200;
 var height = 0;
 var matchMQ;
+var allowCrossDomain;
 var required;
 var prefetch;
 var cssOnly = false;
@@ -76,6 +77,11 @@ while (args.length) {
 		case "-m":
 		case "--match-media-queries":
 			matchMQ = true;
+			break;
+
+		case "-x":
+		case "--allow-cross-domain":
+			allowCrossDomain = true;
 			break;
 
 		case "-r":
@@ -190,6 +196,10 @@ while (args.length) {
 
 var page = webpage.create();
 
+if ( allowCrossDomain ) {
+	page.settings.webSecurityEnabled = false;
+}
+
 page.viewportSize = {
 	width: width,
 	height: height || 800
@@ -268,6 +278,10 @@ page.onLoadFinished = function () {
 
 	if (matchMQ) {
 		options.matchMQ = true;
+	}
+
+	if (allowCrossDomain) {
+		options.allowCrossDomain = true;
 	}
 
 	if (required) {


### PR DESCRIPTION
If you have CSS files located on different domain (e.g. CDN) those files won’t get parsed. This will give users option to allow cross-domain requests.
