### PR TITLE
Fixed height behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ All loading of assets will be loaded relative to the _fake_ url - meaning they n
 ## Changelog
 
 ### next
-
+* Fixed height behavior
 * Ported to Puppeteer
 * Fixed first css selector being ignored when the css file starts with a @charset declaration.
 * `bin` config added to package.json.

--- a/extractCSS.js
+++ b/extractCSS.js
@@ -88,7 +88,7 @@
 
 			// if viewport height is forced
 			// define elements to check seletors against
-			if (html.offsetHeight != height) {
+			if (html.scrollHeight != height) {
 				elements = Array.prototype.slice.call(doc.getElementsByTagName("*")).filter(function (element) {
 					return (element.getBoundingClientRect().top < height);
 				});

--- a/index.js
+++ b/index.js
@@ -471,7 +471,7 @@ while (args.length) {
 	
 		if (!height) {
 			var _height = await page.evaluate(function () {
-				return document.body.offsetHeight;
+				return document.body.scrollHeight;
 			});
 			await page.setViewport({
 				width: width,


### PR DESCRIPTION
There seems to be a bug related to the height check. If height is set to 100%, the  "if (html.offsetHeight != height) {" will not be executed, causing css for the whole page and not just the for specified height to be extracted.

This change tries to fix this behavior.